### PR TITLE
Fix "Using with firebase_auth" Example Code

### DIFF
--- a/facebook_auth/README.md
+++ b/facebook_auth/README.md
@@ -518,7 +518,7 @@ import 'package:firebase_auth/firebase_auth.dart';
     final LoginResult result = await FacebookAuth.instance.login();
     if(result.status == LoginStatus.success){
       // Create a credential from the access token
-      final OAuthCredential credential = FacebookAuthProvider.credential(result.accessToken!);
+      final OAuthCredential credential = FacebookAuthProvider.credential(result.accessToken.token);
       // Once signed in, return the UserCredential
       return await FirebaseAuth.instance.signInWithCredential(credential);
     }


### PR DESCRIPTION
`result.accessToken` is of type AccessToken. Use `result.accessToken.token` instead.

Trying to use `result.accessToken` yields the following error:
![Screenshot 2021-03-27 at 10 15 00](https://user-images.githubusercontent.com/23075874/112716283-b75e5600-8ee5-11eb-8d1e-8568dbd2c7d2.png)
