### PR TITLE
add flexible request

### DIFF
--- a/facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FacebookAuth.java
+++ b/facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FacebookAuth.java
@@ -171,6 +171,33 @@ public class FacebookAuth {
         request.executeAsync();
     }
 
+    /**
+     * Get any data from facebook
+     *
+     * @param id string of fields like "me"
+     * @param fields string of fields like "name,email,picture"
+     * @param result flutter method channel result to send the response to the client
+     */
+    public void graphRequest(String id, String fields, final MethodChannel.Result result) {
+        GraphRequest request = GraphRequest.newGraphPathRequest(
+                AccessToken.getCurrentAccessToken(),
+                id,
+                new GraphRequest.Callback() {
+                    @Override
+                    public void onCompleted(GraphResponse response) {
+                        try {
+                            final JSONObject object = response.getJSONObject();
+                            result.success(object.toString());
+                        } catch (Exception e) {
+                            result.error("FAILED", e.getMessage(), null);
+                        }
+                    }
+                });
+        Bundle parameters = new Bundle();
+        parameters.putString("fields", fields);
+        request.setParameters(parameters);
+        request.executeAsync();
+    }
 
     /**
      * @param accessToken an instance of Facebook SDK AccessToken

--- a/facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FlutterFacebookAuthPlugin.java
+++ b/facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FlutterFacebookAuthPlugin.java
@@ -54,6 +54,12 @@ public class FlutterFacebookAuthPlugin implements FlutterPlugin, MethodCallHandl
                 facebookAuth.getUserData(fields, result);
                 break;
 
+            case "graphRequest":
+                String id = call.argument("id");
+                String _fields = call.argument("fields");
+                facebookAuth.graphRequest(id, _fields, result);
+                break;
+
             case "logOut":
                 facebookAuth.logOut(result);
                 break;

--- a/facebook_auth/ios/Classes/FacebookAuth.swift
+++ b/facebook_auth/ios/Classes/FacebookAuth.swift
@@ -43,6 +43,11 @@ class FacebookAuth: NSObject {
             let fields = args?["fields"] as! String
             getUserData(fields: fields, flutterResult: result)
             
+        case "graphRequest":
+            let id = args?["id"] as! String
+            let fields = args?["fields"] as! String
+            graphRequest(id: id, fields: fields, flutterResult: result)
+            
         case "logOut":
             loginManager.logOut()
             result(nil)
@@ -101,6 +106,22 @@ class FacebookAuth: NSObject {
             }
         }
     }
+    
+    /**
+     retrive any from facebook.
+     */
+    private func graphRequest(id: String, fields: String, flutterResult: @escaping FlutterResult) {
+        let graphRequest : GraphRequest = GraphRequest(graphPath: id, parameters: ["fields":fields])
+        graphRequest.start { (connection, result, error) -> Void in
+            if (error != nil) {
+                self.sendErrorToClient(result: flutterResult, errorCode: "FAILED", message: error!.localizedDescription)
+            } else {
+                let resultDic = result as! NSDictionary
+                flutterResult(resultDic) // sned the response to the client
+            }
+        }
+    }
+    
     
     /**
      Enable or disable the AutoLogAppEvents

--- a/facebook_auth/lib/flutter_facebook_auth.dart
+++ b/facebook_auth/lib/flutter_facebook_auth.dart
@@ -60,6 +60,33 @@ class FacebookAuth implements FacebookAuthPlatform {
   }) =>
       _.getUserData(fields: fields);
 
+  /// request any using the GraphAPI
+  ///
+  /// The facebook SDK will return a JSON like
+  /// ```
+  /// {
+  ///  "name": "Open Graph Test User",
+  ///  "email": "open_jygexjs_user@tfbnw.net",
+  ///  "picture": {
+  ///    "data": {
+  ///      "height": 126,
+  ///      "url": "https://scontent.fuio21-1.fna.fbcdn.net/v/t1.30497-1/s200x200/84628273_176159830277856_972693363922829312_n.jpg",
+  ///      "width": 200
+  ///    }
+  ///  },
+  ///  "id": "136742241592917"
+  ///}
+  ///```
+  ///
+  /// [id] string of id link 12312321321/media
+  /// [fields] string of fields like birthday,email,hometown
+  @override
+  Future<Map<String, dynamic>> graphRequest({
+    required String id,
+    required String fields,
+  }) =>
+      _.graphRequest(id: id, fields: fields);
+
   /// Sign Out from Facebook
   @override
   Future<void> logOut() => _.logOut();

--- a/facebook_auth/test/flutter_facebook_auth_test.dart
+++ b/facebook_auth/test/flutter_facebook_auth_test.dart
@@ -42,6 +42,12 @@ void main() {
               return jsonEncode(data);
             }
             return data;
+          case "graphRequest":
+            final data = mockUserData;
+            if (defaultTargetPlatform == TargetPlatform.android) {
+              return jsonEncode(data);
+            }
+            return data;
           case "isAutoLogAppEventsEnabled":
             return isAutoLogAppEventsEnabled;
 
@@ -63,6 +69,8 @@ void main() {
       expect(result.accessToken, isNotNull);
       expect(await facebookAuth.accessToken, isA<AccessToken>());
       final Map<String, dynamic> userData = await facebookAuth.getUserData();
+      expect(userData.containsKey("email"), true);
+      final Map<String, dynamic> userDataGraphRequest = await facebookAuth.graphRequest(id: "me", fields: "email");
       expect(userData.containsKey("email"), true);
       final FacebookPermissions? permissions = await facebookAuth.permissions;
       expect(permissions, isNotNull);

--- a/facebook_auth_platform_interface/lib/src/facebook_auth_implementation.dart
+++ b/facebook_auth_platform_interface/lib/src/facebook_auth_implementation.dart
@@ -81,6 +81,24 @@ class FacebookAuthPlatformImplementation extends FacebookAuthPlatform {
         : Map<String, dynamic>.from(result); //null  or dynamic data
   }
 
+  /// request any using the GraphAPI
+  ///
+  /// [id] string of id link 12312321321/media
+  /// [fields] string of fields like birthday,email,hometown
+  @override
+  Future<Map<String, dynamic>> graphRequest({
+    required String id,
+    required String fields,
+  }) async {
+    final result = await channel.invokeMethod("graphRequest", {
+      "id": id,
+      "fields": fields,
+    });
+    return isAndroid
+        ? jsonDecode(result)
+        : Map<String, dynamic>.from(result); //null  or dynamic data
+  }
+
   /// Sign Out from Facebook
   @override
   Future<void> logOut() async {

--- a/facebook_auth_platform_interface/lib/src/facebook_auth_plaftorm.dart
+++ b/facebook_auth_platform_interface/lib/src/facebook_auth_plaftorm.dart
@@ -71,6 +71,15 @@ abstract class FacebookAuthPlatform extends PlatformInterface {
     String fields = "name,email,picture.width(200)",
   });
 
+  /// request any using the GraphAPI
+  ///
+  /// [id] string of id link 12312321321/media
+  /// [fields] string of fields like birthday,email,hometown
+  Future<Map<String, dynamic>> graphRequest({
+    required String id,
+    required String fields,
+  });
+
   /// ONLY FOR iOS: enable or disable AutoLogAppEvents
   Future<void> autoLogAppEventsEnabled(bool enabled);
 


### PR DESCRIPTION
## what is this?

add flexible graph request.

Added the function to send arbitrary requests other than user data.

__until now__
```
final mediaData = await anyClient.get("'https://graph.instagram.com/17895695668004550?fields=id,media_type,media_url,username,timestamp&access_token={token}")
");
```

__merge this__
```
final mediaData = await FacebookAuth.i.graphRequest(id: "17895695668004550", field: "id,media_type,media_url,username,timestamp");
```

## thanks

Once these changes are merged, submit the pr for web.