### PR TITLE
FBSDKCoreKit 12.0.x is broken

### DIFF
--- a/facebook_auth/ios/flutter_facebook_auth.podspec
+++ b/facebook_auth/ios/flutter_facebook_auth.podspec
@@ -17,8 +17,8 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
 
 
-  s.dependency 'FBSDKCoreKit', '~> 12.0.2'
-  s.dependency 'FBSDKLoginKit', '~> 12.0.2'
+  s.dependency 'FBSDKCoreKit', '~> 12.1.0'
+  s.dependency 'FBSDKLoginKit', '~> 12.1.0'
   s.platform = :ios, '10.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
See this issue https://github.com/oddbit/flutter_facebook_app_events/issues/159

I confirmed bumping to 12.1.0 fixes the issue
