### PR TITLE
Prefer mavenCentral for Android builds.

### DIFF
--- a/facebook_auth/android/build.gradle
+++ b/facebook_auth/android/build.gradle
@@ -4,6 +4,7 @@ version '1.0'
 buildscript {
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 


### PR DESCRIPTION
https://blog.gradle.org/jcenter-shutdown

jcenter is shutting down and this can cause Android build failures in some regions atm, and globally in the future.