### PR TITLE
Add dataAccessExpirationTime to AccessToken

### DIFF
--- a/facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FacebookAuth.java
+++ b/facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FacebookAuth.java
@@ -183,6 +183,7 @@ public class FacebookAuth {
         put("isExpired", accessToken.isExpired());
         put("grantedPermissions", new ArrayList<>(accessToken.getPermissions()));
         put("declinedPermissions", new ArrayList<>(accessToken.getDeclinedPermissions()));
+        put("dataAccessExpirationTime", accessToken.getDataAccessExpirationTime().getTime());
       }
     };
   }

--- a/facebook_auth/ios/Classes/FacebookAuth.swift
+++ b/facebook_auth/ios/Classes/FacebookAuth.swift
@@ -169,6 +169,7 @@ class FacebookAuth: NSObject {
             "isExpired":accessToken.isExpired,
             "grantedPermissions":accessToken.permissions.map {item in item.name},
             "declinedPermissions":accessToken.declinedPermissions.map {item in item.name},
+            "dataAccessExpirationTime":Int64((accessToken.dataAccessExpirationDate.timeIntervalSince1970*1000).rounded()),
         ] as [String : Any]
         return data;
     }

--- a/facebook_auth/test/src/data.dart
+++ b/facebook_auth/test/src/data.dart
@@ -10,6 +10,7 @@ const mockAccessToken = {
   "isExpired": false,
   "grantedPermissions": ["email", "user_link"],
   "declinedPermissions": [],
+  "dataAccessExpirationTime": 1610201170749,
 };
 
 const mockUserData = {

--- a/facebook_auth_platform_interface/lib/src/access_token.dart
+++ b/facebook_auth_platform_interface/lib/src/access_token.dart
@@ -30,6 +30,9 @@ class AccessToken {
   /// is `true` when the token is expired
   final bool isExpired;
 
+  /// DateTime with the date at which user data access expires
+  final DateTime dataAccessExpirationTime;
+
   AccessToken({
     required this.declinedPermissions,
     required this.grantedPermissions,
@@ -40,6 +43,7 @@ class AccessToken {
     required this.applicationId,
     this.graphDomain,
     required this.isExpired,
+    required this.dataAccessExpirationTime,
   });
 
   /// convert the data provided for the platform channel to one instance of AccessToken
@@ -65,6 +69,8 @@ class AccessToken {
       grantedPermissions: json['grantedPermissions'] != null
           ? List<String>.from(json['grantedPermissions'])
           : null,
+      dataAccessExpirationTime:
+          DateTime.fromMillisecondsSinceEpoch(json['dataAccessExpirationTime']),
     );
   }
 
@@ -79,5 +85,6 @@ class AccessToken {
         'isExpired': isExpired,
         'grantedPermissions': grantedPermissions,
         'declinedPermissions': declinedPermissions,
+        'dataAccessExpirationTime': dataAccessExpirationTime.toIso8601String(),
       };
 }

--- a/facebook_auth_platform_interface/test/mock_data.dart
+++ b/facebook_auth_platform_interface/test/mock_data.dart
@@ -12,6 +12,7 @@ abstract class MockData {
     "isExpired": false,
     "grantedPermissions": ["email", "user_link"],
     "declinedPermissions": [],
+    "dataAccessExpirationTime": 1610201170749,
   };
 
   static Map<String, dynamic> get userData {

--- a/facebook_auth_web/lib/src/facebook_auth_plugin.dart
+++ b/facebook_auth_web/lib/src/facebook_auth_plugin.dart
@@ -278,6 +278,7 @@ class FlutterFacebookAuthPlugin extends FacebookAuthPlatform {
             token: authResponse['accessToken'],
             isExpired: false,
             graphDomain: authResponse['graphDomain'],
+            dataAccessExpirationTime: DateTime.now(),
           ),
         );
       } else if (status == 'unknown') {

--- a/facebook_auth_web/lib/src/facebook_auth_plugin.dart
+++ b/facebook_auth_web/lib/src/facebook_auth_plugin.dart
@@ -260,7 +260,7 @@ class FlutterFacebookAuthPlugin extends FacebookAuthPlatform {
         final Map<String, dynamic> authResponse = response['authResponse'];
 
         final expires = DateTime.now().add(
-          Duration(seconds: authResponse['data_access_expiration_time']),
+          Duration(seconds: authResponse['expiresIn']),
         );
 
         // create a Login Result with an accessToken
@@ -278,7 +278,8 @@ class FlutterFacebookAuthPlugin extends FacebookAuthPlatform {
             token: authResponse['accessToken'],
             isExpired: false,
             graphDomain: authResponse['graphDomain'],
-            dataAccessExpirationTime: DateTime.now(),
+            dataAccessExpirationTime: DateTime.fromMillisecondsSinceEpoch(
+                authResponse['data_access_expiration_time'] * 1000),
           ),
         );
       } else if (status == 'unknown') {


### PR DESCRIPTION
- Add dataAccessExpirationTime to AccessToken
  - expires: A date when the token expires.
  - dataAccessExpirationTime: A date specifying when data access will expire.
    - https://developers.facebook.com/docs/facebook-login/auth-vs-data
- Change data used for expires on the web from data_access_expiration_time to expiresIn
  - Data used for expires in Android and iOS seemed to be expiresIn, so fixed.