### PR TITLE
Update android.md

### DIFF
--- a/website/docs/android.md
+++ b/website/docs/android.md
@@ -54,7 +54,7 @@ Go to [Facebook Login for Android - Quickstart](https://developers.facebook.com/
    <img src="https://user-images.githubusercontent.com/15864336/144253037-f1750fbd-62ac-42fb-88a6-2f7ed8113f3e.png" />
 
     - Open the `/android/app/src/main/AndroidManifest.xml` file.
-    - Add the following uses-permission element after the application element
+    - Add the following uses-permission element before the application element
 
     ```xml
     <uses-permission android:name="android.permission.INTERNET"/>


### PR DESCRIPTION
Update documentation to reflect the correct placement of permissions in the Android Manifest

The documentation for the Flutter package incorrectly stated that permissions should be added after the <application> element in the Android Manifest file. However, upon reviewing the provided code snippet and confirming with the official Android documentation, it is clear that the permissions should be added before the <application> element.

This commit corrects the documentation by replacing the word "after" with "before" to accurately reflect the placement of permissions in the Android Manifest file.