### PR TITLE
fix: #389 [macOS] Terminating app due to uncaught exception 'NSIntern…

### DIFF
--- a/facebook_auth_desktop/macos/Classes/FacebookAuthDesktopPlugin.swift
+++ b/facebook_auth_desktop/macos/Classes/FacebookAuthDesktopPlugin.swift
@@ -58,7 +58,8 @@ public class WebViewController: NSViewController, WKNavigationDelegate {
     var targetUriFragment: String?
     var onComplete: ((String?) -> Void)?
     var onDismissed: (() -> Void)?
-    
+    var window: NSWindow?
+
     public override func loadView() {
         self.title = ""
         let webView = WKWebView(frame: NSMakeRect(0, 0,  980, 720))
@@ -67,6 +68,10 @@ public class WebViewController: NSViewController, WKNavigationDelegate {
         webView.allowsBackForwardNavigationGestures = true
         
         view = webView
+    }
+
+    public override func viewDidAppear() {
+        window = self.view.window!
     }
     
     func loadUrl(_ url: String) {
@@ -99,7 +104,7 @@ public class WebViewController: NSViewController, WKNavigationDelegate {
         if uriString.contains(targetUriFragment!) {
             decisionHandler(.cancel)
             onComplete!(uriString)
-            dismiss(self)
+            window?.performClose(nil);
         } else {
             decisionHandler(.allow)
         }


### PR DESCRIPTION
## Issue
#389 [macOS] Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'dismissViewController:: Error: maybe this view controller was not presented?'

## Cause
`webView` function in `FacebookAuthDesktopPlugin` class was calling `dismiss(self)`. It threw the exception that the function was trying to `dismissViewController` which is not presented (or already closed; maybe it was being called twice). 

## Solution
Instead of calling `dismiss(self)`, created `var window: NSWindow?` and set self.view.window of the WebViewController as below.

```
public override func viewDidAppear() {
        window = self.view.window!
    } 
```

Then replace `dismiss(self)` with ` window?.performClose(nil)` in `webView` function.

