### PR TITLE
add dataAccessExpirationTime property to ClassicToken

### DIFF
--- a/facebook_auth_desktop/lib/facebook_auth_desktop.dart
+++ b/facebook_auth_desktop/lib/facebook_auth_desktop.dart
@@ -165,6 +165,7 @@ class FacebookAuthDesktopPlugin extends FacebookAuthPlatform {
           declinedPermissions: deniedScopes,
           grantedPermissions: grantedScopes,
           userId: userData['id'],
+          dataAccessExpirationTime: DateTime.fromMicrosecondsSinceEpoch(0),
           expires: expiresIn,
           tokenString: token,
           applicationId: _appId,

--- a/facebook_auth_platform_interface/lib/src/access_token.dart
+++ b/facebook_auth_platform_interface/lib/src/access_token.dart
@@ -42,19 +42,22 @@ class LimitedToken extends AccessToken {
 
   @override
   Map<String, dynamic> toJson() => {
-        'type': type.name,
-        'userId': userId,
-        'tokenString': tokenString,
-        'nonce': nonce,
-        'userEmail': userEmail,
-        'userName': userName,
-      };
+    'type': type.name,
+    'userId': userId,
+    'tokenString': tokenString,
+    'nonce': nonce,
+    'userEmail': userEmail,
+    'userName': userName,
+  };
 }
 
 /// Class that contains the facebook access token data
 class ClassicToken extends AccessToken {
   /// DateTime with the expires date of this token
   final DateTime expires;
+
+  /// DateTime with data access expiration time
+  final DateTime dataAccessExpirationTime;
 
   /// the facebook user id
   final String userId;
@@ -75,6 +78,7 @@ class ClassicToken extends AccessToken {
     required this.grantedPermissions,
     required this.userId,
     required this.expires,
+    required this.dataAccessExpirationTime,
     required super.tokenString,
     required this.applicationId,
     this.authenticationToken,
@@ -94,6 +98,12 @@ class ClassicToken extends AccessToken {
           maxMillisecondsSinceEpoch,
         ),
       ),
+      dataAccessExpirationTime: DateTime.fromMillisecondsSinceEpoch(
+        json['dataAccessExpirationTime'].clamp(
+          minMillisecondsSinceEpoch,
+          maxMillisecondsSinceEpoch,
+        ),
+      ),
       authenticationToken: json['authenticationToken'],
       applicationId: json['applicationId'],
       declinedPermissions: json['declinedPermissions'] != null
@@ -108,13 +118,14 @@ class ClassicToken extends AccessToken {
   /// convert this instance to one Map
   @override
   Map<String, dynamic> toJson() => {
-        'type': type.name,
-        'userId': userId,
-        'tokenString': tokenString,
-        'expires': expires.millisecondsSinceEpoch,
-        'applicationId': applicationId,
-        'grantedPermissions': grantedPermissions,
-        'declinedPermissions': declinedPermissions,
-        'authenticationToken': authenticationToken,
-      };
+    'type': type.name,
+    'userId': userId,
+    'tokenString': tokenString,
+    'expires': expires.millisecondsSinceEpoch,
+    'dataAccessExpirationTime': dataAccessExpirationTime.millisecondsSinceEpoch,
+    'applicationId': applicationId,
+    'grantedPermissions': grantedPermissions,
+    'declinedPermissions': declinedPermissions,
+    'authenticationToken': authenticationToken,
+  };
 }


### PR DESCRIPTION
Hi,
Please do not merge this until fixing the code setting the value of dataAccessExpirationTime in facebook_auth_desktop. 
I tested the code only on mobile and couldn't properly test on desktop, so please do and change 
`dataAccessExpirationTime: DateTime.fromMicrosecondsSinceEpoch(0)` to set the value properly.

dataAccessExpirationTime property is a major property that became unavailable after version 7.0.0. As this property encapsulates the time we can use our access token for data access, and not just for authentication (the current `expires` property, which effectively never expires anyway).