### PR TITLE
Fix: Changed token=>tokenString in the AccessToken, for firebase-auth.md

### DIFF
--- a/website/docs/firebase-auth.md
+++ b/website/docs/firebase-auth.md
@@ -9,7 +9,7 @@ Future<UserCredential?> signInWithFacebook() async {
   final LoginResult result = await FacebookAuth.instance.login();
   if(result.status == LoginStatus.success){
     // Create a credential from the access token
-    final OAuthCredential credential = FacebookAuthProvider.credential(result.accessToken!.token);
+    final OAuthCredential credential = FacebookAuthProvider.credential(result.accessToken!.tokenString);
     // Once signed in, return the UserCredential
     return await FirebaseAuth.instance.signInWithCredential(credential);
   }


### PR DESCRIPTION
In the Documentation there is a reference to the field `token` for the `AccessToken` object which is incorrect. Correct one is `tokenString`. 

This is found in a code snippet for Firebase authentication with Facebook as a provider. File: _firebase-auth.md_