### PR TITLE
android: update compileSdkVersion to 36

### DIFF
--- a/facebook_auth/android/build.gradle
+++ b/facebook_auth/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 36
 
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {


### PR DESCRIPTION
This update would make it possible to use the `flutter-facebook-auth` library in apps that have `compileSdkVersion` set to 36.

Otherwise we will get:
<details>
  <summary>Show Log Output</summary>
  Running Gradle task 'assembleDebug'...

FAILURE: Build failed with an exception.

What went wrong:
Execution failed for task ':flutter_facebook_auth:checkDebugAarMetadata'.
A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
19 issues were found when checking AAR metadata:

     1.  Dependency 'androidx.fragment:fragment:1.7.1' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

   2.  Dependency 'androidx.window:window:1.2.0' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

   3.  Dependency 'androidx.window:window-java:1.2.0' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

   4.  Dependency 'androidx.activity:activity:1.8.1' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

   5.  Dependency 'androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

   6.  Dependency 'androidx.lifecycle:lifecycle-livedata:2.7.0' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

   7.  Dependency 'androidx.lifecycle:lifecycle-viewmodel:2.7.0' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

   8.  Dependency 'androidx.lifecycle:lifecycle-livedata-core:2.7.0' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

   9.  Dependency 'androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

  10.  Dependency 'androidx.core:core-ktx:1.13.1' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

  11.  Dependency 'androidx.core:core:1.13.1' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

  12.  Dependency 'androidx.lifecycle:lifecycle-runtime:2.7.0' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

  13.  Dependency 'androidx.lifecycle:lifecycle-process:2.7.0' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

  14.  Dependency 'androidx.savedstate:savedstate:1.2.1' requires libraries and applications that
       depend on it to compile against version 33 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 33, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

  15.  Dependency 'androidx.profileinstaller:profileinstaller:1.3.1' requires libraries and applications that
       depend on it to compile against version 33 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 33, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

  16.  Dependency 'androidx.tracing:tracing:1.2.0' requires libraries and applications that
       depend on it to compile against version 33 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 33, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

  17.  Dependency 'androidx.arch.core:core-runtime:2.2.0' requires libraries and applications that
       depend on it to compile against version 33 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 33, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

  18.  Dependency 'androidx.window.extensions.core:core:1.0.0' requires libraries and applications that
       depend on it to compile against version 33 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 33, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).

  19.  Dependency 'androidx.annotation:annotation-experimental:1.4.0' requires libraries and applications that
       depend on it to compile against version 34 or later of the
       Android APIs.

       :flutter_facebook_auth is currently compiled against android-31.

       Recommended action: Update this project to use a newer compileSdk
       of at least 34, for example 36.

       Note that updating a library or application's compileSdk (which
       allows newer APIs to be used) can be done separately from updating
       targetSdk (which opts the app in to new runtime behavior) and
       minSdk (which determines which devices the app can be installed
       on).
  </details>