### PR TITLE
chore(deps): bump flutter_secure_storage to ^10.0.0 in facebook_auth_desktop

### DIFF
--- a/facebook_auth_desktop/pubspec.yaml
+++ b/facebook_auth_desktop/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.2.2
-  flutter_secure_storage: ^9.2.2
+  flutter_secure_storage: ^10.0.0
   flutter_facebook_auth_platform_interface: ^6.1.2
 
   # flutter_facebook_auth_platform_interface:


### PR DESCRIPTION
Bump flutter_secure_storage to ^10.0.0 to allow newer web 'js' transitive upgrades (unblocks projects wanting js ^0.7.x). This addresses issue #480 and will help downstream projects upgrade h3_flutter. Change is limited to macOS plugin dependency and should be safe; tests pass locally in the downstream project. Please consider merging or advise if additional changes are required.