### PR TITLE
feat(iOS): Adopt FlutterSceneLifeCycleDelegate for UIScene apps

### DIFF
--- a/facebook_auth/CHANGELOG.md
+++ b/facebook_auth/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 7.1.5+uiscene.1
+- feat(iOS): Adopt `FlutterSceneLifeCycleDelegate` so the native Facebook app
+  login callback (the `fb<APP_ID>://` URL scheme) reaches the SDK on apps that
+  have migrated to the UIScene lifecycle. Without this, the OS routes URL
+  openings to the scene delegate, which the plugin previously did not observe,
+  causing native FB-app logins to silently fail.
+- Bumps minimum Flutter version to 3.38.0 (required by
+  `FlutterSceneLifeCycleDelegate`).
+
 ## 7.1.5
 - Use fixed version of `FBSDKLoginKit` to avoid issues on iOS.
 

--- a/facebook_auth/ios/Classes/SwiftFlutterFacebookAuthPlugin.swift
+++ b/facebook_auth/ios/Classes/SwiftFlutterFacebookAuthPlugin.swift
@@ -4,7 +4,7 @@ import UIKit
 import FBSDKCoreKit
 
 
-public class SwiftFlutterFacebookAuthPlugin: NSObject, FlutterPlugin {
+public class SwiftFlutterFacebookAuthPlugin: NSObject, FlutterPlugin, FlutterSceneLifeCycleDelegate {
     let facebookAuth = FacebookAuth()
     public static func register(with registrar: FlutterPluginRegistrar) {
         ApplicationDelegate.initialize()
@@ -12,14 +12,15 @@ public class SwiftFlutterFacebookAuthPlugin: NSObject, FlutterPlugin {
         let instance = SwiftFlutterFacebookAuthPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)
         registrar.addApplicationDelegate(instance)
+        registrar.addSceneDelegate(instance)
     }
-    
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         self.facebookAuth.handle(call, result: result)
     }
 
-    
-    
+
+
     /// START ALLOW HANDLE NATIVE FACEBOOK APP
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
         var options = [UIApplication.LaunchOptionsKey: Any]()
@@ -30,13 +31,26 @@ public class SwiftFlutterFacebookAuthPlugin: NSObject, FlutterPlugin {
         ApplicationDelegate.shared.application(application,didFinishLaunchingWithOptions: options)
         return true
     }
-    
+
     public func application( _ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:] ) -> Bool {
         let processed = ApplicationDelegate.shared.application(
             app, open: url,
             sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
             annotation: options[UIApplication.OpenURLOptionsKey.annotation])
         return processed;
+    }
+
+    // Scene lifecycle equivalent of `application(_:open:options:)`. iOS 13+
+    // routes URL openings (including the native Facebook app callback via the
+    // fb<APP_ID>:// scheme) here when UIApplicationSceneManifest is enabled.
+    public func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        for context in URLContexts {
+            _ = ApplicationDelegate.shared.application(
+                UIApplication.shared,
+                open: context.url,
+                sourceApplication: context.options.sourceApplication,
+                annotation: context.options.annotation as Any)
+        }
     }
     /// END ALLOW HANDLE NATIVE FACEBOOK APP
 }

--- a/facebook_auth/pubspec.yaml
+++ b/facebook_auth/pubspec.yaml
@@ -1,11 +1,11 @@
 name: flutter_facebook_auth
 description: The easiest way to add facebook login to your flutter app. Feature includes getting user information, profile picture and more. This plugin also supports Web and macOS.
-version: 7.1.5
+version: 7.1.5+uiscene.1
 homepage: https://github.com/darwin-morocho/flutter-facebook-auth
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.2"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Problem

Fixes #484 

Apps that have migrated to the [UIScene lifecycle](https://flutter.dev/to/uiscene-migration) lose the native Facebook app login callback.

When `UIApplicationSceneManifest` is set in the host app's `Info.plist`, iOS routes URL openings to the scene delegate via `scene(_:openURLContexts:)` rather than to the application delegate's `application(_:open:options:)`. This plugin currently registers only via `addApplicationDelegate`, so the FB SDK never receives the `fb<APP_ID>://` callback when a user logs in via the native Facebook app — login appears to hang indefinitely on iOS 13+ apps that have migrated.

(`ASWebAuthenticationSession` flows — Limited Login, and the no-FB-app web fallback — are unaffected because the system handles their callback URLs internally. Only the native FB-app handoff path breaks.)

Flutter 3.41 ships with auto-migration to the UIScene lifecycle for hosts that don't customize `AppDelegate`, and Apple has signaled that UIScene support will be required on a future iOS version, so adopting the new lifecycle is no longer optional for many users.

## Fix

- Conform `SwiftFlutterFacebookAuthPlugin` to `FlutterSceneLifeCycleDelegate`.
- Call `registrar.addSceneDelegate(instance)` alongside the existing `addApplicationDelegate` registration.
- Add a `scene(_:openURLContexts:)` method that forwards URL contexts to `ApplicationDelegate.shared.application(_:open:sourceApplication:annotation:)` — the same FB SDK entry point the existing `application(_:open:options:)` handler uses.

The legacy `application(_:open:options:)` handler is retained, so hosts that have **not** migrated to UIScene continue to work exactly as before.

## Compatibility

\`FlutterSceneLifeCycleDelegate\` was added in Flutter 3.38. Bumping the package's minimum Flutter version from 3.19.2 to 3.38.0 to match.

## Testing

Verified end-to-end on a real iOS device (iOS 17) with:
- Host app migrated to UIScene (\`UIApplicationSceneManifest\` in \`Info.plist\` pointing at \`FlutterSceneDelegate\`)
- Facebook native app installed and logged in
- Both Limited Login (no behavior change — was never broken) and the merge-flow re-prompt path (\`getMergeCredential\` after Firebase \`CredentialAlreadyInUse\`)

Without this patch, the native-FB-app handoff stalls — the user sees the FB app open, taps "Continue", returns to the host app, and the Dart \`login()\` future never resolves. With this patch, the URL callback reaches the SDK and login completes normally.

Filed as draft for maintainer feedback on whether the minimum Flutter version bump is acceptable, or whether the conformance should be guarded so older Flutter versions can still build.