### PR TITLE
fix(android): align Java + Kotlin JVM targets to 17

### DIFF
--- a/facebook_auth/android/build.gradle
+++ b/facebook_auth/android/build.gradle
@@ -20,6 +20,7 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 36
@@ -31,6 +32,16 @@ android {
     defaultConfig {
         minSdkVersion 21
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+
     lintOptions {
         disable 'InvalidPackage'
     }


### PR DESCRIPTION
## Summary
- The plugin still ships a Kotlin entry point (`FacebookAuthPlugin.kt`) alongside the Java code, but `android/build.gradle` declares neither the `kotlin-android` plugin nor any JVM target.
- Kotlin Gradle Plugin 2.x detects the `.kt` file, auto-applies the Kotlin compile path, and **validates** Java/Kotlin target compatibility. The Java task defaults to 1.8 while the Kotlin task inherits the build JDK (commonly 21 on AGP-bundled JBR), producing:

```
Inconsistent JVM-target compatibility detected for tasks
'compileReleaseJavaWithJavac' (1.8) and 'compileReleaseKotlin' (21).
```

- The build then fails fatally for every consumer on KGP 2.x.

## Fix
Explicitly apply `kotlin-android`, set Java `sourceCompatibility`/`targetCompatibility` to 17, and pin `kotlinOptions.jvmTarget = '17'` so both compile tasks agree.

## Test plan
- [ ] `flutter build appbundle --release` in a Flutter app using a recent SDK (Kotlin 2.x / KGP 2.x) — no JVM-target validation failure.
- [ ] Existing functionality unchanged (FB login flow still works on Android).