### PR TITLE
feat(android): forward nonce to native login for OIDC id token

### DIFF
--- a/flutter_facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FacebookAuth.java
+++ b/flutter_facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FacebookAuth.java
@@ -10,6 +10,7 @@ import com.facebook.GraphRequest;
 import com.facebook.GraphResponse;
 import com.facebook.LoginStatusCallback;
 import com.facebook.login.LoginBehavior;
+import com.facebook.login.LoginConfiguration;
 import com.facebook.login.LoginManager;
 
 import org.json.JSONObject;
@@ -36,16 +37,22 @@ public class FacebookAuth {
    *
    * @param activity the android activity to handle onActivityResult event
    * @param permissions list of permissions
+   * @param nonce optional nonce used to request an OIDC id token (AuthenticationToken)
    * @param result flutter method channel result to send the response to the client
    */
-  void login(Activity activity, List<String> permissions, MethodChannel.Result result) {
+  void login(Activity activity, List<String> permissions, String nonce, MethodChannel.Result result) {
     final boolean hasPreviousSession = AccessToken.getCurrentAccessToken() != null;
     if (hasPreviousSession) {
       loginManager.logOut();
     }
     final boolean isOk = resultDelegate.setPendingResult(result);
     if (isOk) {
-      loginManager.logIn(activity, permissions);
+      if (nonce != null && !nonce.isEmpty()) {
+        LoginConfiguration configuration = new LoginConfiguration(permissions, nonce);
+        loginManager.logIn(activity, configuration);
+      } else {
+        loginManager.logIn(activity, permissions);
+      }
     }
   }
 

--- a/flutter_facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FacebookLoginResultDelegate.java
+++ b/flutter_facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FacebookLoginResultDelegate.java
@@ -2,6 +2,7 @@ package app.meedu.flutter_facebook_auth;
 
 
 import android.content.Intent;
+import com.facebook.AuthenticationToken;
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
@@ -29,6 +30,10 @@ class FacebookLoginResultDelegate implements FacebookCallback<LoginResult>, Plug
     @Override
     public void onSuccess(LoginResult loginResult) {
         final HashMap<String, Object> accessToken = FacebookAuth.getAccessToken(loginResult.getAccessToken());
+        final AuthenticationToken authenticationToken = loginResult.getAuthenticationToken();
+        if (authenticationToken != null) {
+            accessToken.put("authenticationToken", authenticationToken.getToken());
+        }
         finishWithResult(accessToken);// send response to the client
     }
 

--- a/flutter_facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FlutterFacebookAuthPlugin.java
+++ b/flutter_facebook_auth/android/src/main/java/app/meedu/flutter_facebook_auth/FlutterFacebookAuthPlugin.java
@@ -38,8 +38,9 @@ public class FlutterFacebookAuthPlugin implements FlutterPlugin, MethodCallHandl
             case "login":
                 List<String> permissions = call.argument("permissions");
                 String loginBehavior = call.argument("loginBehavior");
+                String nonce = call.argument("nonce");
                 facebookAuth.setLoginBehavior(loginBehavior);
-                facebookAuth.login(this.activityPluginBinding.getActivity(), permissions, result);
+                facebookAuth.login(this.activityPluginBinding.getActivity(), permissions, nonce, result);
                 break;
             case "expressLogin":
                 facebookAuth.expressLogin(this.activityPluginBinding.getActivity(), result);

--- a/flutter_facebook_auth/test/flutter_facebook_auth_test.dart
+++ b/flutter_facebook_auth/test/flutter_facebook_auth_test.dart
@@ -140,6 +140,54 @@ void main() {
       expect(token.authenticationToken, isNull);
     });
 
+    test('login: forwards nonce and permissions to the native layer', () async {
+      MethodCall? captured;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        channel,
+        (MethodCall call) async {
+          if (call.method == 'login') {
+            captured = call;
+            return mockAccessTokenWithAuthenticationToken;
+          }
+          return null;
+        },
+      );
+
+      await facebookAuth.login(
+        permissions: ['email', 'public_profile', 'openid'],
+        loginBehavior: LoginBehavior.nativeWithFallback,
+        nonce: 'my-test-nonce',
+      );
+
+      expect(captured, isNotNull);
+      final args = Map<String, dynamic>.from(captured!.arguments as Map);
+      expect(args['nonce'], 'my-test-nonce');
+      expect(args['permissions'], containsAll(['email', 'public_profile', 'openid']));
+      expect(args['loginBehavior'], 'NATIVE_WITH_FALLBACK');
+    });
+
+    test('login: nonce is null in native arguments when not provided', () async {
+      MethodCall? captured;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        channel,
+        (MethodCall call) async {
+          if (call.method == 'login') {
+            captured = call;
+            return mockAccessToken;
+          }
+          return null;
+        },
+      );
+
+      await facebookAuth.login();
+
+      expect(captured, isNotNull);
+      final args = Map<String, dynamic>.from(captured!.arguments as Map);
+      expect(args['nonce'], isNull);
+    });
+
     test('expressLogin: authenticationToken is populated when native layer returns it', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(


### PR DESCRIPTION
## What

On Android, forward the `nonce` into `LoginConfiguration` and surface the returned `AuthenticationToken` (OIDC id token) on the result. iOS already exposes the `AuthenticationToken`; Android was ignoring it, so `ClassicToken.authenticationToken` was always null there.

## Changes

- `FacebookAuth.login` reads the `nonce` argument and, when present, logs in with a `LoginConfiguration(permissions, nonce)` so the SDK requests an OIDC id token.
- `FacebookLoginResultDelegate.onSuccess` extracts `loginResult.getAuthenticationToken()` and includes it in the response.
- `FlutterFacebookAuthPlugin` passes the `nonce` argument through the method channel.

## Why

Consumers that verify an OIDC id token (for example Supabase's `signInWithIdToken`) need the `AuthenticationToken`. This makes the Android side able to return it, matching iOS.

## Note on Android behavior

Facebook's Limited Login (the OIDC id token flow) is [documented as iOS-only](https://developers.facebook.com/docs/facebook-login/limited-login/). On Android, Facebook mints the `AuthenticationToken` only on a full (first) authorization; repeat native logins return a classic access token with a null `AuthenticationToken`, and there is no SDK-side way to force it (see facebook/facebook-android-sdk#1132). So this PR reliably surfaces the id token on iOS and on the first Android authorization, which is all Facebook exposes. It does not, and cannot, guarantee an id token on every Android login. That's a Facebook platform limitation, not something the plugin can work around.
