### PR TITLE
fix: report Facebook config failures instead of throwing

### DIFF
--- a/facebook_auth_desktop/CHANGELOG.md
+++ b/facebook_auth_desktop/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.1
+- Fixed an unhandled exception when Facebook rejects the login for a configuration reason. Those failures arrive as `error_code`/`error_message` with no token, which fell through to a null check operator instead of returning `LoginStatus.failed`.
+
 ## 2.2.0
 - Added Swift Package Manager (SPM) support for macOS. The plugin now ships a `Package.swift` (sources under `macos/facebook_auth_desktop/Sources/`) while keeping the podspec for CocoaPods compatibility.
 

--- a/facebook_auth_desktop/lib/facebook_auth_desktop.dart
+++ b/facebook_auth_desktop/lib/facebook_auth_desktop.dart
@@ -150,16 +150,39 @@ class FacebookAuthDesktopPlugin extends FacebookAuthPlatform {
         );
       }
 
+      // Facebook reports app configuration problems -- a redirect URI missing
+      // from the app's allow list, embedded browser login turned off -- with
+      // `error_code`/`error_message` rather than `error`, and sends no token.
+      // Without this the flow would fall through to the token handling below
+      // and turn a reportable failure into an unhandled exception.
+      final errorCode = uri.queryParameters['error_code'];
+      if (errorCode != null) {
+        return LoginResult(
+          status: LoginStatus.failed,
+          message: uri.queryParameters['error_message'] ??
+              'Login failed with error $errorCode.',
+        );
+      }
+
       String? token = arguments['long_lived_token'];
       bool isLoginLiveToken = token != null;
 
       late final DateTime expiresIn;
 
       if (!isLoginLiveToken) {
-        token = arguments['access_token']!;
+        token = arguments['access_token'];
+        if (token == null) {
+          return LoginResult(
+            status: LoginStatus.failed,
+            message: 'Facebook did not return an access token.',
+          );
+        }
         expiresIn = DateTime.now().add(
           Duration(
-            seconds: int.parse(arguments['expires_in']!),
+            // A token always arrives with its lifetime; fall back to the
+            // length of a short-lived token rather than throwing if it does
+            // not, since the token itself is still usable.
+            seconds: int.tryParse(arguments['expires_in'] ?? '') ?? 3600,
           ),
         );
       } else {
@@ -168,8 +191,8 @@ class FacebookAuthDesktopPlugin extends FacebookAuthPlatform {
         );
       }
 
-      final grantedScopes = arguments['granted_scopes']!.split(',');
-      final deniedScopes = arguments['denied_scopes']!.split(',');
+      final grantedScopes = arguments['granted_scopes']?.split(',') ?? const [];
+      final deniedScopes = arguments['denied_scopes']?.split(',') ?? const [];
 
       final response = await _httpClient.get(
         Uri.parse('https://graph.facebook.com/me?access_token=$token'),

--- a/facebook_auth_desktop/pubspec.yaml
+++ b/facebook_auth_desktop/pubspec.yaml
@@ -1,6 +1,6 @@
 name: facebook_auth_desktop
 description: macOS support for flutter_facebook_auth
-version: 2.2.0
+version: 2.2.1
 homepage: https://github.com/darwin-morocho/flutter-facebook-auth/tree/master/facebook_auth_desktop
 
 environment:

--- a/facebook_auth_desktop/test/facebook_auth_desktop_test.dart
+++ b/facebook_auth_desktop/test/facebook_auth_desktop_test.dart
@@ -120,6 +120,65 @@ void main() {
   );
 
   test(
+    'login > app misconfigured reports failed rather than throwing',
+    () async {
+      // Facebook signals configuration problems -- an unlisted redirect URI,
+      // embedded browser login disabled -- with error_code/error_message and
+      // no token at all.
+      channel.setMockMethodCallHandler((MethodCall call) async {
+        switch (call.method) {
+          case "signIn":
+            return 'https://www.facebook.com/connect/login_success.html'
+                '?error_code=191'
+                '&error_message=Can%27t+load+URL%3A+the+domain+of+this+URL'
+                '+is+not+included+in+the+app%27s+domains';
+        }
+      });
+
+      final plugin = FacebookAuthDesktopPlugin(
+        httpClient: MockHttpClient(),
+      );
+
+      plugin.webAndDesktopInitialize(
+        appId: 'appId',
+        cookie: true,
+        xfbml: true,
+        version: 'v13.0',
+      );
+
+      final result = await plugin.login();
+      expect(result.status, LoginStatus.failed);
+      expect(result.message, contains("Can't load URL"));
+    },
+  );
+
+  test(
+    'login > redirect without an access token reports failed',
+    () async {
+      channel.setMockMethodCallHandler((MethodCall call) async {
+        switch (call.method) {
+          case "signIn":
+            return 'https://www.facebook.com/connect/login_success.html#state=abc';
+        }
+      });
+
+      final plugin = FacebookAuthDesktopPlugin(
+        httpClient: MockHttpClient(),
+      );
+
+      plugin.webAndDesktopInitialize(
+        appId: 'appId',
+        cookie: true,
+        xfbml: true,
+        version: 'v13.0',
+      );
+
+      final result = await plugin.login();
+      expect(result.status, LoginStatus.failed);
+    },
+  );
+
+  test(
     'login > logged',
     () async {
       int i = 0;


### PR DESCRIPTION
## Summary

`login()` on desktop throws an unhandled exception instead of returning
`LoginStatus.failed` whenever Facebook rejects the login for a configuration
reason. The plugin knows the login has failed and crashes rather than saying so.

This is not platform-specific — the path is shared by macOS and Windows. I hit it
on a real sign-in against an app whose `Embedded browser OAuth login` was
disabled, and it reproduces on macOS identically.

```
Null check operator used on a null value
#0  FacebookAuthDesktopPlugin.login (package:facebook_auth_desktop/facebook_auth_desktop.dart:159:42)
```

## Cause

The guard checks only the `error` query parameter:

```dart
final error = uri.queryParameters['error'];
if (error != null) { ... }
```

But Facebook reports app configuration problems — a domain missing from the app,
embedded browser login turned off — with **`error_code`/`error_message`** instead,
and sends no token at all. That guard misses, execution reaches

```dart
token = arguments['access_token']!;
```

and the null check operator throws. `granted_scopes` and `denied_scopes` are
force-unwrapped the same way a few lines below.

## Changes

- Handle `error_code`/`error_message`, returning `LoginStatus.failed` and
  surfacing Facebook's own `error_message` so the caller can show why.
- Stop force-unwrapping `access_token`; a redirect without one now returns
  `LoginStatus.failed` rather than throwing.
- Stop force-unwrapping `granted_scopes`/`denied_scopes`. Absent values become
  empty lists; an empty *string* still behaves exactly as before.
- `expires_in` falls back to the length of a short-lived token instead of
  throwing, since a token that arrives without one is still usable.

## Tests

Two regression tests, both of which **fail on the current code** with the same
`Null check operator used on a null value` this was found by:

- `login > app misconfigured reports failed rather than throwing`
- `login > redirect without an access token reports failed`

8/8 pass with the fix. No existing test changed.

## Note

Bumped to `2.2.1` as a patch. This overlaps with #500 on `CHANGELOG.md`
and `pubspec.yaml` only; whichever lands second needs a one-line rebase.

